### PR TITLE
Updated with right format for NotificationHandler.asks_permission and details about 1.59.4

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,10 +11,20 @@ import time
 #     packagename=u'org.test.notifyapp',
 #     servicename=u'Notify'
 # )
+def check_permission(granted):
+    if granted:
+        print("Notification Permission granted")
+    else:
+        print("Notification Permission denied")
+        
+NotificationHandler.asks_permission(check_permission)
+# .asks_permission() method purpose is to do the below code
+#permissions = [Permission.POST_NOTIFICATIONS]
+#request_permissions(permissions)
 
-NotificationHandler.asks_permission(Permission.POST_NOTIFICATIONS)
-permissions = [Permission.POST_NOTIFICATIONS]
-request_permissions(permissions)
+# But since you said permission is already granted then the problem is from has_permission using
+# a function from android check_permission(Permission.POST_NOTIFICATIONS) that is not returning the right value 
+# In v1.59.4 will create a method `send_` that doesn't check for permission
 
 KV = """
 Button:


### PR DESCRIPTION
#`NotificationHandler.asks_permission(callback_fun)` 
actually does 👇 
`permissions = [Permission.POST_NOTIFICATIONS]
request_permissions(permissions)`
and takes a callback function that is called after user choose whether to allow notification or not.

# Permission not granted to send notifications issue
`Notification.send()` calls `has_permission` which uses an internal android function to check for permission, the function is not returning the right value 
## In v1.59.4 will create a method `send_` that doesn't use the function